### PR TITLE
OSX: try a simpler, alternate method to obtain IP if the 'universal' method fails.

### DIFF
--- a/oakupsrv.py
+++ b/oakupsrv.py
@@ -24,8 +24,15 @@ def printStatus(str):
 def getHost():
 	# From:
 	# http://stackoverflow.com/questions/166506/finding-local-ip-addresses-using-pythons-stdlib
-	return ([l for l in ([ip for ip in socket.gethostbyname_ex(socket.gethostname())[2] if not ip.startswith("127.")][:1], [[(s.connect(('8.8.8.8', 53)), s.getsockname()[0], s.close()) for s in [socket.socket(socket.AF_INET, socket.SOCK_DGRAM)]][0][1]]) if l][0][0])
-
+	try:
+		return ([l for l in ([ip for ip in socket.gethostbyname_ex(socket.gethostname())[2] if not ip.startswith("127.")][:1], [[(s.connect(('8.8.8.8', 53)), s.getsockname()[0], s.close()) for s in [socket.socket(socket.AF_INET, socket.SOCK_DGRAM)]][0][1]]) if l][0][0])
+	except:
+		s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+		s.connect(("gmail.com",80))
+		ip = s.getsockname()[0]
+		s.close()
+		return ip
+		
 def validateCertHost(key_fname, cert_fname, tprint_fname, host):
 	cert_host = ""
 	try:


### PR DESCRIPTION
On my MacBook Pro (El Capitan, OSX 10.11.3), the 'universal' method for getting the machine's IP number was throwing an error. This will catch the error and try a simpler method, if necessary. 
